### PR TITLE
Filter on place and amenity places to find default location

### DIFF
--- a/WebContent/base/OSRM.Geocoder.js
+++ b/WebContent/base/OSRM.Geocoder.js
@@ -68,9 +68,10 @@ _onclickResult: function(marker_id, lat, lon) {
 // filter default place in Nominatim's response
 _getDefaultPlace: function(response) {
 	// preferred classes
-	var preferred = ['place', 'tourism', 'amenity'];
+	var preferred = ['place', 'tourism', 'amenity', 'railway'] ;
 	var pref_order = new Array();
 	pref_order['place'] = ['country', 'state', 'city', 'town', 'county', 'village', 'hamlet'];
+	pref_order['railway'] = ['station'];
 
 	for (var p=0; p < preferred.length; p++) {
 		if (pref_order[preferred[p]]) {

--- a/WebContent/base/OSRM.Geocoder.js
+++ b/WebContent/base/OSRM.Geocoder.js
@@ -65,6 +65,23 @@ _onclickResult: function(marker_id, lat, lon) {
 },
 
 
+// filter default place in Nominatim's response
+_getDefaultPlace: function(response) {
+	// preferred classes
+	var preferred = ['place', 'amenity'];
+
+	for (var p=0; p < preferred.length; p++) {
+		for (var i=0; i < response.length; i++) {
+			if (response[i]['class'] == preferred[p]) {
+				return response[i];
+			}
+		}
+	}
+
+	return response[0];
+},
+
+
 // process geocoder response
 _showResults: function(response, parameters) {
 	if(!response){
@@ -78,7 +95,8 @@ _showResults: function(response, parameters) {
 	}
 	
 	// show first result
-	OSRM.Geocoder._onclickResult(parameters.marker_id, response[0].lat, response[0].lon);
+	var defaultPlace = OSRM.Geocoder._getDefaultPlace(response);
+	OSRM.Geocoder._onclickResult(parameters.marker_id, defaultPlace.lat, defaultPlace.lon);
 	if( OSRM.G.markers.route.length > 1 )		// if a route is displayed, we don't need to show other possible geocoding results
 		return;
 	

--- a/WebContent/base/OSRM.Geocoder.js
+++ b/WebContent/base/OSRM.Geocoder.js
@@ -68,12 +68,24 @@ _onclickResult: function(marker_id, lat, lon) {
 // filter default place in Nominatim's response
 _getDefaultPlace: function(response) {
 	// preferred classes
-	var preferred = ['place', 'amenity'];
+	var preferred = ['place', 'tourism', 'amenity'];
+	var pref_order = new Array();
+	pref_order['place'] = ['country', 'state', 'city', 'town', 'county', 'village', 'hamlet'];
 
 	for (var p=0; p < preferred.length; p++) {
-		for (var i=0; i < response.length; i++) {
-			if (response[i]['class'] == preferred[p]) {
-				return response[i];
+		if (pref_order[preferred[p]]) {
+			for (var j=0; j < pref_order[preferred[p]].length; j++) {
+				for (var i=0; i < response.length; i++) {
+					if (response[i]['class'] == preferred[p] && response[i]['type'] == pref_order[preferred[p]][j]) {
+						return response[i];
+					}
+				}
+			}
+		} else {
+			for (var i=0; i < response.length; i++) {
+				if (response[i]['class'] == preferred[p]) {
+					return response[i];
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR aims to fix bug 277: https://github.com/DennisOSRM/Project-OSRM/issues/277

It filters the JSON returned by Nominatim in order to avoid setting places on boundaries (which happens for most places), e.g. when searching for a town.

For now, the implementation is a bit rough, but it allows to find cities, towns, villages, amenities, etc. pretty well.

Ideally, I'm thinking of an implementation that would give a weight to classes, types, and distances from the other point (either start, end, or current view). For example, a place would get 100 points while an amenity would get 90. If the place is a country, then it would get 10 more, so 110, while a city would get 9, so 109, etc. In addition to that, distance would play a role, so that you could find a village if it's close to your start point, even if a bigger city far way bears the same name.
