### PR TITLE
Display class and type in results

### DIFF
--- a/WebContent/base/OSRM.Geocoder.js
+++ b/WebContent/base/OSRM.Geocoder.js
@@ -94,6 +94,7 @@ _showResults: function(response, parameters) {
  
 		html += '<tr class="'+rowstyle+'">';
 		html += '<td class="results-body-counter"><span">'+(i+1)+'.</span></td>';
+		html += '<td class="results-body-class" onclick="OSRM.Geocoder._onclickResult(\''+parameters.marker_id+'\', '+result.lat+', '+result.lon+');"><span">'+result.class+'/'+result.type+'</span></td>';
 		html += '<td class="results-body-items">';
 
 		if(result.display_name){

--- a/WebContent/main.css
+++ b/WebContent/main.css
@@ -348,6 +348,16 @@ html, body {
 	color:#ff0000
 }
 
+.results-body-class
+{
+	vertical-align:top;
+	cursor:pointer;
+	color:#000000
+}
+.results-body-class:hover
+{
+	color:#ff0000
+}
 
 /* style for main-output information-box -> table (driving directions) */
 .description


### PR DESCRIPTION
Having a choice between Nominatim results is nice, but it's often hard to tell what results are. This PR displays the class and type for each result in the list.

Ideally, the list would show icons representing them, with a title on the images.
