### PR TITLE
allow engine 0 to be selected via URL

### DIFF
--- a/WebContent/main.js
+++ b/WebContent/main.js
@@ -250,7 +250,7 @@ OSRM.parseParameters = function(){
 		return;
 	
 	// storage for parameter values
-	var params = {};
+	var params = { active_routing_engine : OSRM.DEFAULTS.ROUTING_ENGINE };
 
 	// parse input
 	var splitted_url = called_url.split('&');
@@ -355,7 +355,7 @@ OSRM.parseParameters = function(){
 		OSRM.G.active_alternative = params.active_alternative || 0;
 		
 		// set routing server
-		OSRM.GUI.setRoutingEngine( params.active_routing_engine || OSRM.DEFAULTS.ROUTING_ENGINE );
+		OSRM.GUI.setRoutingEngine( params.active_routing_engine );
 			
 		// compute route
 		OSRM.Routing.getRoute({keepAlternative:true});


### PR DESCRIPTION
Fixes a bit of a corner case where multiple routing engines are configured and the first one (number 0) is not the default engine. If in that case engine 0 was selected via URL parameter, active_routing_engine resolved to false and thus, the default engine was chosen instead.
