### PR TITLE
Japanese 'name' property fix, etc

### DIFF
--- a/WebContent/OSRM.config.js
+++ b/WebContent/OSRM.config.js
@@ -68,7 +68,7 @@ OSRM.DEFAULTS = {
 		{encoding:"fi", name:"Suomi"},
 		{encoding:"fr", name:"Français"},
 		{encoding:"it", name:"Italiano"},
-		{encoding:"ja", name:"日本人"},
+		{encoding:"ja", name:"日本語"},
 		{encoding:"ka", name:"ქართული"},
 		{encoding:"lv", name:"Latviešu"},
 		{encoding:"nb", name:"Bokmål"},

--- a/WebContent/localization/OSRM.Locale.ja.js
+++ b/WebContent/localization/OSRM.Locale.ja.js
@@ -22,7 +22,7 @@ or see http://www.gnu.org/licenses/agpl.txt.
 OSRM.Localization["ja"] = {
 // own language
 "CULTURE": "ja-JP",
-"LANGUAGE": "日本人",
+"LANGUAGE": "日本語",
 // gui
 "GUI_START": "開始",
 "GUI_END": "終了",

--- a/WebContent/main.html
+++ b/WebContent/main.html
@@ -142,7 +142,7 @@ or see http://www.gnu.org/licenses/agpl.txt.
 <div id="config-content" class="box-content">
 	<!-- header -->
 	<div id="config-toggle" class="iconic-button cancel-marker top-right-button"></div>
-	<div id="gui-config-label" class="box-label">Configuraion</div>
+	<div id="gui-config-label" class="box-label">Configuration</div>
 
 	<!-- config options -->
 	<div class="full">


### PR DESCRIPTION
Fixed the name of the Japanese localization (doesn't seem particularly user facing, but whatever). `日本人` refers to Japanese people, while `日本語` refers to the Japanese language.

Also fixed "Configuration" spelling error in main.html.
